### PR TITLE
libvmod-urlocde for Varnish 7.x versions

### DIFF
--- a/src/vmod_urlcode.c
+++ b/src/vmod_urlcode.c
@@ -74,60 +74,63 @@ vmod_hex_to_int(char c)
 	return (-1);
 }
 
-const char *
-vmod_decode(const struct vrt_ctx *ctx, const char *str, ...)
+VCL_STRING
+vmod_decode(VRT_CTX, VCL_STRANDS s)
 {
 	char *b, *e;
 	int h, l;
 	unsigned u;
-	va_list ap;
 	int percent = 0;
+    int i = 0;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 	u = WS_ReserveAll(ctx->ws);
 	e = b = ctx->ws->f;
 	e += u;
-	va_start(ap, str);
-	while (b < e && str != vrt_magic_string_end)
+
+	while (b < e && i < s->n)
 	{
-		if (str == NULL || *str == '\0')
-		{
-			str = va_arg(ap, const char *);
-		}
-		else if (percent == 0)
-		{
-			switch (*str)
-			{
-			case '%':
-				percent = 1;
-				str++;
-				break;
-			case '+':
-				*b++ = ' ';
-				str++;
-				break;
-			default:
-				*b++ = *str++;
-				break;
-			}
-		}
-		else if (percent == 1)
-		{
-			h = vmod_hex_to_int(*str++);
-			if (h < 0)
-				b = e;
-			percent = 2;
-		}
-		else if (percent == 2)
-		{
-			l = vmod_hex_to_int(*str++);
-			if (l < 0)
-				b = e;
-			*b++ = (char)((h << 4) | l);
-			percent = 0;
-		}
+        const char *str = s->p[i];
+
+        while(*str)
+        {
+            if (percent == 0)
+            {
+                switch (*str)
+                {
+                    case '%':
+                        percent = 1;
+                        str++;
+                        break;
+                    case '+':
+                        *b++ = ' ';
+                        str++;
+                        break;
+                    default:
+                        *b++ = *str++;
+                        break;
+                }
+            }
+            else if (percent == 1)
+            {
+                h = vmod_hex_to_int(*str++);
+                if (h < 0)
+                    b = e;
+                percent = 2;
+            }
+            else if (percent == 2)
+            {
+                l = vmod_hex_to_int(*str++);
+                if (l < 0)
+                    b = e;
+                *b++ = (char)((h << 4) | l);
+                percent = 0;
+            }
+        }
+        i++;
 	}
+
 	if (b < e)
 		*b = '\0';
 	b++;

--- a/src/vmod_urlcode.c
+++ b/src/vmod_urlcode.c
@@ -10,21 +10,21 @@ static char hexchars[] = "0123456789ABCDEF";
 #define visalnum(c) \
 	((c >= '0' && c <= '9') || visalpha(c))
 
-const char *
-vmod_encode(const struct vrt_ctx *ctx, const char *str, ...)
+VCL_STRING
+vmod_encode(VRT_CTX, VCL_STRANDS s)
 {
 	char *b, *e;
 	unsigned u;
-	va_list ap;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);
 	u = WS_ReserveAll(ctx->ws);
 	e = b = ctx->ws->f;
 	e += u;
-	va_start(ap, str);
-	while (b < e && str != vrt_magic_string_end)
+
+    for(int i=0; i < s->n; i++)
 	{
+        const char *str = s->p[i];
 		while (b < e && str && *str)
 		{
 			if (visalnum((int)*str) || *str == '-' || *str == '.' || *str == '_' || *str == '~')
@@ -44,7 +44,6 @@ vmod_encode(const struct vrt_ctx *ctx, const char *str, ...)
 				str++;
 			}
 		}
-		str = va_arg(ap, const char *);
 	}
 	if (b < e)
 		*b = '\0';

--- a/src/vmod_urlcode.c
+++ b/src/vmod_urlcode.c
@@ -81,7 +81,7 @@ vmod_decode(VRT_CTX, VCL_STRANDS s)
 	int h, l;
 	unsigned u;
 	int percent = 0;
-    int i = 0;
+	int i = 0;
 
 	CHECK_OBJ_NOTNULL(ctx, VRT_CTX_MAGIC);
 	CHECK_OBJ_NOTNULL(ctx->ws, WS_MAGIC);

--- a/src/vmod_urlcode.vcc
+++ b/src/vmod_urlcode.vcc
@@ -1,3 +1,3 @@
 $Module urlcode 3 urlencode/urldecode functions vmod
-$Function STRING encode(STRING_LIST)
-$Function STRING decode(STRING_LIST)
+$Function STRING encode(STRANDS)
+$Function STRING decode(STRANDS)


### PR DESCRIPTION
Rewritten libvmod-urlocde varnish module to acommodate the changes introduced by the version 7.x of Varnish Cache.

i.e:
```
* Removed depcreated ``STRING_LIST`` in favor of ``STRANDS``. All functions
  that previously took a ``STRING_LIST`` had ``const char *, ...`` arguments,
  they now take ``const char *, VCL_STRANDS`` arguments. The magic cookie
  ``vrt_magic_string_end`` is gone and ``VRT_CollectStrands()`` was renamed to
  ``VRT_STRANDS_string()``.
```

